### PR TITLE
Add FastAPI example app

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,18 @@
-# Codex
-Sandbox for Codex testing
+# Codex Example App
+
+This repository contains a minimal example application using **FastAPI** for the backend and a small HTML/JavaScript/CSS front‑end.
+
+## Running locally
+
+1. Install dependencies:
+   ```bash
+   pip install -r requirements.txt
+   ```
+2. Start the server:
+   ```bash
+   python main.py
+   ```
+3. Open your browser at [http://localhost:8000](http://localhost:8000) to see the app.
+
+The page fetches a greeting from `/api/hello` and lets you submit a message to `/api/echo`. Responses are displayed dynamically on the page.
+

--- a/main.py
+++ b/main.py
@@ -1,0 +1,24 @@
+from fastapi import FastAPI, Request
+from fastapi.responses import FileResponse, JSONResponse
+from fastapi.staticfiles import StaticFiles
+
+app = FastAPI(title="Example App")
+
+app.mount("/static", StaticFiles(directory="static"), name="static")
+
+@app.get("/", response_class=FileResponse)
+async def read_index():
+    return FileResponse("static/index.html")
+
+@app.get("/api/hello")
+async def get_hello():
+    return {"message": "Hello from FastAPI!"}
+
+@app.post("/api/echo")
+async def post_echo(data: dict):
+    message = data.get("message", "")
+    return {"echo": message}
+
+if __name__ == "__main__":
+    import uvicorn
+    uvicorn.run(app, host="0.0.0.0", port=8000)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+fastapi
+uvicorn

--- a/static/index.html
+++ b/static/index.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Example App</title>
+    <link rel="stylesheet" href="/static/styles.css">
+</head>
+<body>
+    <div class="container">
+        <h1>FastAPI Example</h1>
+        <p id="hello">Loading greeting...</p>
+        <form id="echoForm">
+            <input id="echoInput" type="text" placeholder="Say something" required>
+            <button type="submit">Echo</button>
+        </form>
+        <p id="echoOutput"></p>
+    </div>
+    <script src="/static/script.js"></script>
+</body>
+</html>

--- a/static/script.js
+++ b/static/script.js
@@ -1,0 +1,21 @@
+document.addEventListener('DOMContentLoaded', () => {
+    fetch('/api/hello')
+        .then(res => res.json())
+        .then(data => {
+            document.getElementById('hello').textContent = data.message;
+        });
+
+    const form = document.getElementById('echoForm');
+    form.addEventListener('submit', async (e) => {
+        e.preventDefault();
+        const text = document.getElementById('echoInput').value;
+        const res = await fetch('/api/echo', {
+            method: 'POST',
+            headers: {'Content-Type': 'application/json'},
+            body: JSON.stringify({message: text})
+        });
+        const data = await res.json();
+        document.getElementById('echoOutput').textContent = data.echo;
+        form.reset();
+    });
+});

--- a/static/styles.css
+++ b/static/styles.css
@@ -1,0 +1,44 @@
+body {
+    margin: 0;
+    font-family: Arial, sans-serif;
+    background: linear-gradient(135deg, #3f87a6, #ebf8e1);
+    min-height: 100vh;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.container {
+    background: white;
+    padding: 2rem;
+    border-radius: 8px;
+    box-shadow: 0 2px 8px rgba(0,0,0,0.2);
+    max-width: 400px;
+    width: 100%;
+    text-align: center;
+}
+
+input[type="text"] {
+    padding: 0.5rem;
+    width: 70%;
+    border: 1px solid #ccc;
+    border-radius: 4px;
+}
+
+button {
+    padding: 0.5rem 1rem;
+    background: #3f87a6;
+    color: white;
+    border: none;
+    border-radius: 4px;
+    cursor: pointer;
+}
+
+button:hover {
+    background: #34697d;
+}
+
+#echoOutput {
+    margin-top: 1rem;
+    font-weight: bold;
+}


### PR DESCRIPTION
## Summary
- create a simple FastAPI backend and serve static files
- add modern HTML/CSS/JS frontend to call API routes
- document running the example

## Testing
- `python -m py_compile main.py`
- `python main.py & sleep 2; pkill -f main.py`