### PR TITLE
Add example FastAPI app with modern frontend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/README.md
+++ b/README.md
@@ -1,1 +1,24 @@
+# Example FastAPI App
 
+This repository contains a minimal example of a web application using **FastAPI** for the backend and a simple HTML/JS/CSS frontend.
+
+## Requirements
+
+- Python 3.8+
+- `fastapi` and `uvicorn`
+
+Install dependencies:
+
+```bash
+pip install -r requirements.txt
+```
+
+## Running the app
+
+Run the server with:
+
+```bash
+uvicorn backend.main:app --reload
+```
+
+Then open [http://localhost:8000](http://localhost:8000) in your browser.

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,0 +1,21 @@
+from fastapi import FastAPI
+from fastapi.staticfiles import StaticFiles
+from fastapi.responses import FileResponse
+from pathlib import Path
+
+app = FastAPI(title="Example App")
+
+# Serve static files
+static_dir = Path(__file__).resolve().parent.parent / "frontend" / "static"
+app.mount("/static", StaticFiles(directory=static_dir), name="static")
+
+
+@app.get("/")
+def read_index():
+    index_path = Path(__file__).resolve().parent.parent / "frontend" / "index.html"
+    return FileResponse(index_path)
+
+
+@app.get("/api/hello")
+def read_hello(name: str = "World"):
+    return {"message": f"Hello, {name}!"}

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Example App</title>
+    <link rel="stylesheet" href="/static/style.css">
+</head>
+<body>
+    <div class="container">
+        <h1 id="greeting">Loading...</h1>
+        <input type="text" id="nameInput" placeholder="Enter your name" />
+        <button id="greetBtn">Greet</button>
+    </div>
+    <script src="/static/script.js"></script>
+</body>
+</html>

--- a/frontend/static/script.js
+++ b/frontend/static/script.js
@@ -1,0 +1,22 @@
+document.addEventListener('DOMContentLoaded', () => {
+    const greeting = document.getElementById('greeting');
+    const nameInput = document.getElementById('nameInput');
+    const greetBtn = document.getElementById('greetBtn');
+
+    const fetchGreeting = async (name = 'World') => {
+        try {
+            const response = await fetch(`/api/hello?name=${encodeURIComponent(name)}`);
+            const data = await response.json();
+            greeting.textContent = data.message;
+        } catch (err) {
+            greeting.textContent = 'Error fetching greeting';
+        }
+    };
+
+    greetBtn.addEventListener('click', () => {
+        const name = nameInput.value.trim() || 'World';
+        fetchGreeting(name);
+    });
+
+    fetchGreeting();
+});

--- a/frontend/static/style.css
+++ b/frontend/static/style.css
@@ -1,0 +1,32 @@
+body {
+    font-family: Arial, sans-serif;
+    background: #f5f7fa;
+    margin: 0;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    height: 100vh;
+}
+
+.container {
+    background: #fff;
+    padding: 2rem;
+    box-shadow: 0 0 10px rgba(0, 0, 0, 0.1);
+    border-radius: 8px;
+    text-align: center;
+}
+
+button {
+    margin-top: 1rem;
+    padding: 0.5rem 1rem;
+    font-size: 1rem;
+    border: none;
+    border-radius: 4px;
+    background: #007bff;
+    color: #fff;
+    cursor: pointer;
+}
+
+button:hover {
+    background: #0056b3;
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+fastapi
+uvicorn


### PR DESCRIPTION
## Summary
- create FastAPI backend serving an API endpoint and static files
- add simple HTML/JS/CSS frontend
- document setup and usage in README

## Testing
- `pip install -r requirements.txt`
- `uvicorn backend.main:app --port 8000 --reload` *(fails: Address already in use but endpoint reachable)*
- `curl -s http://localhost:8000/api/hello?name=ChatGPT`